### PR TITLE
Ability to filter and sort todos

### DIFF
--- a/app/components/FilterBar.tsx
+++ b/app/components/FilterBar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { FilterType } from "@/app/lib/types/todo";
+import { useTodoStore } from "@/app/lib/store/StoreProvider";
+import { getActiveCount, getCompletedCount } from "@/app/lib/logic/filterLogic";
+
+export function FilterBar() {
+  const todos = useTodoStore((state) => state.todos);
+  const filter = useTodoStore((state) => state.filter);
+  const setFilter = useTodoStore((state) => state.setFilter);
+  const clearCompleted = useTodoStore((state) => state.clearCompleted);
+
+  const activeCount = getActiveCount(todos);
+  const completedCount = getCompletedCount(todos);
+
+  const filterButtons: { label: string; value: FilterType }[] = [
+    { label: "All", value: "all" },
+    { label: "Active", value: "active" },
+    { label: "Completed", value: "completed" },
+  ];
+
+  return (
+    <div className="border-t border-border p-4 space-y-4">
+      {/* Status Counts */}
+      <div className="flex gap-6 text-sm text-gray-600">
+        <span>
+          Active: <strong className="text-black">{activeCount}</strong>
+        </span>
+        <span>
+          Completed: <strong className="text-black">{completedCount}</strong>
+        </span>
+      </div>
+
+      {/* Filter Buttons */}
+      <div className="flex gap-2">
+        {filterButtons.map((btn) => (
+          <button
+            key={btn.value}
+            onClick={() => setFilter(btn.value)}
+            className={`px-4 py-2 text-sm border rounded transition-colors ${
+              filter === btn.value
+                ? "bg-black text-white border-black"
+                : "bg-white text-black border-border hover:bg-gray-50"
+            }`}
+          >
+            {btn.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Clear Completed Button */}
+      {completedCount > 0 && (
+        <button
+          onClick={clearCompleted}
+          className="px-4 py-2 text-sm border border-border rounded hover:bg-black hover:text-white transition-colors"
+        >
+          Clear Completed
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/components/TodoList.tsx
+++ b/app/components/TodoList.tsx
@@ -2,9 +2,13 @@
 
 import { useTodoStore } from "@/app/lib/store/StoreProvider";
 import { TodoItem } from "./TodoItem";
+import { filterTodos } from "@/app/lib/logic/filterLogic";
 
 export function TodoList() {
   const todos = useTodoStore((state) => state.todos);
+  const filter = useTodoStore((state) => state.filter);
+
+  const filteredTodos = filterTodos(todos, filter);
 
   if (todos.length === 0) {
     return (
@@ -14,9 +18,17 @@ export function TodoList() {
     );
   }
 
+  if (filteredTodos.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted">
+        No {filter} todos.
+      </div>
+    );
+  }
+
   return (
     <ul className="border border-border rounded overflow-hidden">
-      {todos.map((todo) => (
+      {filteredTodos.map((todo) => (
         <TodoItem key={todo.id} todo={todo} />
       ))}
     </ul>

--- a/app/lib/logic/filterLogic.ts
+++ b/app/lib/logic/filterLogic.ts
@@ -1,0 +1,46 @@
+import { Todo, FilterType } from "@/app/lib/types/todo";
+
+/**
+ * Filters todos based on the filter type
+ * @param todos - List of todos to filter
+ * @param filter - Filter type: "all", "active", or "completed"
+ * @returns Filtered array of todos
+ */
+export function filterTodos(todos: Todo[], filter: FilterType): Todo[] {
+  switch (filter) {
+    case "active":
+      return todos.filter((todo) => !todo.completed);
+    case "completed":
+      return todos.filter((todo) => todo.completed);
+    case "all":
+    default:
+      return todos;
+  }
+}
+
+/**
+ * Gets the count of active (incomplete) todos
+ * @param todos - List of todos
+ * @returns Number of active todos
+ */
+export function getActiveCount(todos: Todo[]): number {
+  return todos.filter((todo) => !todo.completed).length;
+}
+
+/**
+ * Gets the count of completed todos
+ * @param todos - List of todos
+ * @returns Number of completed todos
+ */
+export function getCompletedCount(todos: Todo[]): number {
+  return todos.filter((todo) => todo.completed).length;
+}
+
+/**
+ * Removes all completed todos from the list
+ * @param todos - Current list of todos
+ * @returns New array without completed todos
+ */
+export function clearCompleted(todos: Todo[]): Todo[] {
+  return todos.filter((todo) => !todo.completed);
+}

--- a/app/lib/store/todoStore.ts
+++ b/app/lib/store/todoStore.ts
@@ -1,18 +1,23 @@
 import { create } from "zustand";
-import { Todo } from "@/app/lib/types/todo";
+import { Todo, FilterType } from "@/app/lib/types/todo";
 import { addTodo, deleteTodo, toggleTodo, editTodo } from "@/app/lib/logic/todoLogic";
+import { clearCompleted as clearCompletedLogic } from "@/app/lib/logic/filterLogic";
 
 export interface TodoStore {
   todos: Todo[];
+  filter: FilterType;
   addTodo: (text: string) => void;
   deleteTodo: (id: string) => void;
   toggleTodo: (id: string) => void;
   editTodo: (id: string, newText: string) => void;
+  setFilter: (filter: FilterType) => void;
+  clearCompleted: () => void;
 }
 
 export const createTodoStore = () => {
   return create<TodoStore>((set) => ({
     todos: [],
+    filter: "all",
     addTodo: (text: string) =>
       set((state) => ({ todos: addTodo(state.todos, text) })),
     deleteTodo: (id: string) =>
@@ -21,6 +26,10 @@ export const createTodoStore = () => {
       set((state) => ({ todos: toggleTodo(state.todos, id) })),
     editTodo: (id: string, newText: string) =>
       set((state) => ({ todos: editTodo(state.todos, id, newText) })),
+    setFilter: (filter: FilterType) =>
+      set({ filter }),
+    clearCompleted: () =>
+      set((state) => ({ todos: clearCompletedLogic(state.todos) })),
   }));
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import { AddTodoForm } from "./components/AddTodoForm";
 import { TodoList } from "./components/TodoList";
+import { FilterBar } from "./components/FilterBar";
 
 export default function Home() {
   return (
@@ -10,6 +11,7 @@ export default function Home() {
         </h1>
         <AddTodoForm />
         <TodoList />
+        <FilterBar />
       </div>
     </main>
   );

--- a/tests/logic/filterLogic.test.ts
+++ b/tests/logic/filterLogic.test.ts
@@ -1,0 +1,150 @@
+import { describe, test, expect } from "bun:test";
+import {
+  filterTodos,
+  getActiveCount,
+  getCompletedCount,
+  clearCompleted,
+} from "@/app/lib/logic/filterLogic";
+import type { Todo } from "@/app/lib/types/todo";
+
+describe("filterLogic", () => {
+  const mockTodos: Todo[] = [
+    { id: "1", text: "Active todo 1", completed: false, createdAt: Date.now() },
+    { id: "2", text: "Completed todo 1", completed: true, createdAt: Date.now() },
+    { id: "3", text: "Active todo 2", completed: false, createdAt: Date.now() },
+    { id: "4", text: "Completed todo 2", completed: true, createdAt: Date.now() },
+    { id: "5", text: "Active todo 3", completed: false, createdAt: Date.now() },
+  ];
+
+  describe("filterTodos", () => {
+    test("returns all todos when filter is 'all'", () => {
+      const filtered = filterTodos(mockTodos, "all");
+      expect(filtered).toHaveLength(5);
+      expect(filtered).toEqual(mockTodos);
+    });
+
+    test("returns only active todos when filter is 'active'", () => {
+      const filtered = filterTodos(mockTodos, "active");
+      expect(filtered).toHaveLength(3);
+      expect(filtered.every((todo) => !todo.completed)).toBe(true);
+    });
+
+    test("returns only completed todos when filter is 'completed'", () => {
+      const filtered = filterTodos(mockTodos, "completed");
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every((todo) => todo.completed)).toBe(true);
+    });
+
+    test("returns empty array when no todos match filter", () => {
+      const allCompleted: Todo[] = [
+        { id: "1", text: "Completed", completed: true, createdAt: Date.now() },
+      ];
+      const filtered = filterTodos(allCompleted, "active");
+      expect(filtered).toHaveLength(0);
+    });
+
+    test("does not mutate original array", () => {
+      const original = [...mockTodos];
+      filterTodos(mockTodos, "active");
+      expect(mockTodos).toEqual(original);
+    });
+  });
+
+  describe("getActiveCount", () => {
+    test("returns correct count of active todos", () => {
+      const count = getActiveCount(mockTodos);
+      expect(count).toBe(3);
+    });
+
+    test("returns 0 when all todos are completed", () => {
+      const allCompleted: Todo[] = [
+        { id: "1", text: "Completed", completed: true, createdAt: Date.now() },
+        { id: "2", text: "Completed", completed: true, createdAt: Date.now() },
+      ];
+      const count = getActiveCount(allCompleted);
+      expect(count).toBe(0);
+    });
+
+    test("returns correct count when all todos are active", () => {
+      const allActive: Todo[] = [
+        { id: "1", text: "Active", completed: false, createdAt: Date.now() },
+        { id: "2", text: "Active", completed: false, createdAt: Date.now() },
+      ];
+      const count = getActiveCount(allActive);
+      expect(count).toBe(2);
+    });
+
+    test("returns 0 for empty array", () => {
+      const count = getActiveCount([]);
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("getCompletedCount", () => {
+    test("returns correct count of completed todos", () => {
+      const count = getCompletedCount(mockTodos);
+      expect(count).toBe(2);
+    });
+
+    test("returns 0 when all todos are active", () => {
+      const allActive: Todo[] = [
+        { id: "1", text: "Active", completed: false, createdAt: Date.now() },
+        { id: "2", text: "Active", completed: false, createdAt: Date.now() },
+      ];
+      const count = getCompletedCount(allActive);
+      expect(count).toBe(0);
+    });
+
+    test("returns correct count when all todos are completed", () => {
+      const allCompleted: Todo[] = [
+        { id: "1", text: "Completed", completed: true, createdAt: Date.now() },
+        { id: "2", text: "Completed", completed: true, createdAt: Date.now() },
+      ];
+      const count = getCompletedCount(allCompleted);
+      expect(count).toBe(2);
+    });
+
+    test("returns 0 for empty array", () => {
+      const count = getCompletedCount([]);
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("clearCompleted", () => {
+    test("removes all completed todos", () => {
+      const result = clearCompleted(mockTodos);
+      expect(result).toHaveLength(3);
+      expect(result.every((todo) => !todo.completed)).toBe(true);
+    });
+
+    test("returns empty array when all todos are completed", () => {
+      const allCompleted: Todo[] = [
+        { id: "1", text: "Completed", completed: true, createdAt: Date.now() },
+        { id: "2", text: "Completed", completed: true, createdAt: Date.now() },
+      ];
+      const result = clearCompleted(allCompleted);
+      expect(result).toHaveLength(0);
+    });
+
+    test("returns same todos when none are completed", () => {
+      const allActive: Todo[] = [
+        { id: "1", text: "Active", completed: false, createdAt: Date.now() },
+        { id: "2", text: "Active", completed: false, createdAt: Date.now() },
+      ];
+      const result = clearCompleted(allActive);
+      expect(result).toHaveLength(2);
+      expect(result).toEqual(allActive);
+    });
+
+    test("does not mutate original array", () => {
+      const original = [...mockTodos];
+      clearCompleted(mockTodos);
+      expect(mockTodos).toEqual(original);
+    });
+
+    test("returns empty array for empty input", () => {
+      const result = clearCompleted([]);
+      expect(result).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds a filter feature to the todo application, allowing users to view active, completed, or all todos, and to clear completed todos. It introduces a new `FilterBar` component, updates the store logic to support filtering, and adds comprehensive tests for the new filtering logic.

**Filter functionality and UI enhancements:**

* Added the `FilterBar` component to provide filter buttons (All, Active, Completed), display counts of active/completed todos, and allow clearing completed todos. (`app/components/FilterBar.tsx`) [[1]](diffhunk://#diff-597b4820b9eeddadb97e65bed50c46d77641d1c64293ca118a5645a494e9694aR1-R62) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R3) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R14)
* Updated the `TodoList` component to use the selected filter and display a message when no todos match the filter. (`app/components/TodoList.tsx`) [[1]](diffhunk://#diff-eab0ad23200466cbb07406be7e06e00909d389a7697b928ec103eba72a390581R5-R11) [[2]](diffhunk://#diff-eab0ad23200466cbb07406be7e06e00909d389a7697b928ec103eba72a390581R21-R31)

**Filtering logic and store updates:**

* Implemented filtering and count logic in a new file, including functions for filtering todos, getting active/completed counts, and clearing completed todos. (`app/lib/logic/filterLogic.ts`)
* Extended the todo store to support filter state, filter changes, and clearing completed todos. (`app/lib/store/todoStore.ts`) [[1]](diffhunk://#diff-203af46443d31cad1679bf0fbaae0b11d1fcf70a1495cdfe2bd4a2bfda53306cL2-R20) [[2]](diffhunk://#diff-203af46443d31cad1679bf0fbaae0b11d1fcf70a1495cdfe2bd4a2bfda53306cR29-R32)

**Testing:**

* Added unit tests for filtering logic, active/completed counts, and clearing completed todos, ensuring correctness and immutability. (`tests/logic/filterLogic.test.ts`)